### PR TITLE
#278 Feature add config max inbound message body size

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/rabbitmqclient/QuarkusRabbitmqReadyCheckTest.java
+++ b/deployment/src/test/java/io/quarkiverse/rabbitmqclient/QuarkusRabbitmqReadyCheckTest.java
@@ -226,6 +226,11 @@ public class QuarkusRabbitmqReadyCheckTest {
             }
 
             @Override
+            public int maxInboundMessageBodySize() {
+                return 0;
+            }
+
+            @Override
             public int networkRecoveryInterval() {
                 return 0;
             }

--- a/docs/modules/ROOT/pages/includes/quarkus-rabbitmqclient.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-rabbitmqclient.adoc
@@ -315,6 +315,27 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
+a| [[quarkus-rabbitmqclient_quarkus-rabbitmqclient-max-inbound-message-body-size]]`link:#quarkus-rabbitmqclient_quarkus-rabbitmqclient-max-inbound-message-body-size[quarkus.rabbitmqclient.max-inbound-message-body-size]`
+
+`link:#quarkus-rabbitmqclient_quarkus-rabbitmqclient-max-inbound-message-body-size[quarkus.rabbitmqclient."client-name".max-inbound-message-body-size]`
+
+
+[.description]
+--
+Maximum body size of inbound (received) messages in bytes.
+
+Default value is 67,108,864 (64 MiB).
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_RABBITMQCLIENT_MAX_INBOUND_MESSAGE_BODY_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_RABBITMQCLIENT_MAX_INBOUND_MESSAGE_BODY_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`134217728`
+
+
 a| [[quarkus-rabbitmqclient_quarkus-rabbitmqclient-network-recovery-interval]]`link:#quarkus-rabbitmqclient_quarkus-rabbitmqclient-network-recovery-interval[quarkus.rabbitmqclient.network-recovery-interval]`
 
 `link:#quarkus-rabbitmqclient_quarkus-rabbitmqclient-network-recovery-interval[quarkus.rabbitmqclient."client-name".network-recovery-interval]`

--- a/runtime/src/main/java/io/quarkiverse/rabbitmqclient/RabbitMQClientConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/rabbitmqclient/RabbitMQClientConfig.java
@@ -105,6 +105,15 @@ public interface RabbitMQClientConfig {
     int requestedFrameMax();
 
     /**
+     * Maximum body size of inbound (received) messages in bytes.
+     *
+     * <p>
+     * Default value is 67,108,864 (64 MiB).
+     */
+    @WithDefault("67108864")
+    int maxInboundMessageBodySize();
+
+    /**
      * Network recovery interval in milliseconds
      */
     @WithDefault("" + ConnectionFactory.DEFAULT_NETWORK_RECOVERY_INTERVAL)

--- a/runtime/src/main/java/io/quarkiverse/rabbitmqclient/RabbitMQHelper.java
+++ b/runtime/src/main/java/io/quarkiverse/rabbitmqclient/RabbitMQHelper.java
@@ -49,6 +49,7 @@ class RabbitMQHelper {
         cf.setSaslConfig(params.getConfig().sasl().getSaslConfig());
 
         ConnectionFactoryConfigurator.load(cf, newProperties(params), "");
+        cf.setMaxInboundMessageBodySize(params.getConfig().maxInboundMessageBodySize());
 
         String uri = params.getConfig().uri().orElse(null);
         if (uri != null) {
@@ -96,7 +97,8 @@ class RabbitMQHelper {
     }
 
     /**
-     * Compute the {@link Properties} for use with {@link ConnectionFactoryConfigurator}.
+     * Compute the {@link Properties} for use with
+     * {@link ConnectionFactoryConfigurator}.
      *
      * @param params the {@link RabbitMQClientParams}.
      * @return the computed properties.


### PR DESCRIPTION
Add Client Configuration maxInboundMessageBodySize for RabbitMQ ConnectionFactory, the Default value is 64 MiB