### PR TITLE
move quarkus-junit5 to quarkus-junit

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
fix: updated dependency on moved artifact quarkus-junit5 -> quarkus-junit